### PR TITLE
Ensure files and sort attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+###1.0.1
+
+Fix documentation format and add Context config example
+
 ###1.0.0
 
 * New Context parameters for configuring context.xml:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -412,6 +412,7 @@ class tomcat::config {
   # - $jpda_opts_real
   # - $custom_variables
   file { 'tomcat environment variables':
+    ensure  => file,
     path    => $::tomcat::config_path_real,
     content => template("${module_name}/common/setenv.erb"),
     owner   => $::tomcat::tomcat_user_real,
@@ -423,6 +424,7 @@ class tomcat::config {
   if $::osfamily == 'RedHat' {
     # make sure system variables are in the right place
     file { 'tomcat default variables':
+      ensure  => file,
       path    => "${::tomcat::catalina_base_real}/conf/${::tomcat::service_name_real}.conf",
       content => "# See ${::tomcat::config_path_real}"
     }

--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -43,7 +43,7 @@ class tomcat::install::archive {
     group   => $::tomcat::tomcat_group_real,
     strip   => 1
   }
-  
+
   # ordering
   Staging::Extract <| title == "apache-tomcat-${::tomcat::version}.tar.gz" |> -> File <| tag == 'tomcat_tree' |>
 
@@ -66,7 +66,7 @@ class tomcat::install::archive {
     alias  => 'tomcat logs directory',
     tag    => 'tomcat_tree'
   }
-  
+
   # pid file management
   file { 'tomcat pid file':
     ensure => present,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -250,7 +250,7 @@ define tomcat::instance (
     } } else {
     $service_name_real = $service_name
   }
-  
+
   if $archive_source == undef {
     $archive_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version}/bin/apache-tomcat-${version}.tar.gz"
   } else {
@@ -368,7 +368,7 @@ define tomcat::instance (
     } } else {
     $security_manager_real = $security_manager
   }
-  
+
   $engine_defaulthost_real = $engine_defaulthost ? {
     undef   => $host_name,
     default => $engine_defaulthost
@@ -377,7 +377,7 @@ define tomcat::instance (
   $java_opts_real = join($java_opts, ' ')
   $catalina_opts_real = join($catalina_opts, ' ')
   $jpda_opts_real = join($jpda_opts, ' ')
-  
+
   # generate params hash
   $server_params_real = merge(delete_undef_values({
     'port'     => $server_control_port,
@@ -509,7 +509,7 @@ define tomcat::instance (
     # ordering
     Staging::Extract <| title == "apache-tomcat-${version}.tar.gz" |> -> File <| tag == "instance_${name}_tree" |>
   }
-  
+
   # create/ensure instance directory tree
   if $catalina_base_real != $catalina_home_real {
     file {
@@ -587,7 +587,7 @@ define tomcat::instance (
       path   => "${catalina_base_real}/conf/policy.d/catalina.policy"
     }
   }
-  
+
   # pid file management
   if $::tomcat::install_from == 'archive' {
     file { "instance ${name} pid file":
@@ -649,6 +649,7 @@ define tomcat::instance (
 
         # create init script
         file { "${service_name_real} service unit":
+          ensure  => file,
           path    => "/etc/init.d/${service_name_real}",
           owner   => 'root',
           group   => 'root',
@@ -658,7 +659,7 @@ define tomcat::instance (
       }
     }
   }
-  
+
   service { $service_name_real:
     ensure  => $service_ensure,
     enable  => $service_enable,
@@ -757,7 +758,7 @@ define tomcat::instance (
       target  => "instance ${name} server configuration"
     }
   }
-  
+
   # Template uses:
   # - $ssl_connector
   # - $ssl_port
@@ -769,7 +770,7 @@ define tomcat::instance (
       target  => "instance ${name} server configuration"
     }
   }
-  
+
   # Template uses:
   # - $ajp_connector
   # - $ajp_port
@@ -784,7 +785,7 @@ define tomcat::instance (
       target  => "instance ${name} server configuration"
     }
   }
-  
+
   # Template uses:
   # - $connectors
   if $connectors and $connectors != [] {
@@ -794,7 +795,7 @@ define tomcat::instance (
       target  => "instance ${name} server configuration"
     }
   }
-  
+
   # Template uses:
   # - $engine_params_real
   concat::fragment { "instance ${name} server.xml engine":
@@ -1007,6 +1008,7 @@ define tomcat::instance (
   # - $jpda_opts_real
   # - $custom_variables
   file { "instance ${name} environment variables":
+    ensure  => file,
     path    => $config_path_real,
     content => template("${module_name}/common/setenv.erb"),
     owner   => $::tomcat::tomcat_user_real,
@@ -1079,10 +1081,12 @@ define tomcat::instance (
       } ->
       file {
         "instance ${name} manager.xml":
+          ensure  => file,
           path    => "${catalina_base_real}/conf/Catalina/${host_name}/manager.xml",
           content => template("${module_name}/instance/manager.xml.erb");
 
         "instance ${name} host-manager.xml":
+          ensure  => file,
           path    => "${catalina_base_real}/conf/Catalina/${host_name}/host-manager.xml",
           content => template("${module_name}/instance/host-manager.xml.erb")
       }

--- a/manifests/service/archive.pp
+++ b/manifests/service/archive.pp
@@ -18,6 +18,7 @@ class tomcat::service::archive {
     # manage systemd unit on compatible systems
     if $::osfamily == 'Suse' { # SuSE
       file { "${::tomcat::service_name_real} service unit":
+        ensure  => file,
         path    => "/usr/lib/systemd/system/${::tomcat::service_name_real}.service",
         owner   => 'root',
         group   => 'root',
@@ -25,6 +26,7 @@ class tomcat::service::archive {
       }
     } elsif $::operatingsystem == 'Fedora' and $::operatingsystemmajrelease >= '20' { # Fedora 20+
       file { "${::tomcat::service_name_real} service unit":
+        ensure  => file,
         path    => "/usr/lib/systemd/system/${::tomcat::service_name_real}.service",
         owner   => 'root',
         group   => 'root',
@@ -32,6 +34,7 @@ class tomcat::service::archive {
       }
     } else { # RHEL 7+ or Fedora 17-19
       file { "${::tomcat::service_name_real} service unit":
+        ensure  => file,
         path    => "/usr/lib/systemd/system/${::tomcat::service_name_real}.service",
         owner   => 'root',
         group   => 'root',
@@ -45,6 +48,7 @@ class tomcat::service::archive {
 
     # create init script
     file { "${::tomcat::service_name_real} service unit":
+      ensure  => file,
       path    => "/etc/init.d/${::tomcat::service_name_real}",
       owner   => 'root',
       group   => 'root',
@@ -52,7 +56,7 @@ class tomcat::service::archive {
       content => template("${module_name}/instance/tomcat_init_generic.erb")
     }
   }
-  
+
   service { $::tomcat::service_name_real:
     ensure  => $::tomcat::service_ensure,
     enable  => $::tomcat::service_enable,

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "aco-tomcat",
   "summary": "Puppet module for Tomcat",
   "author": "Antoine Cotten",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "project_page": "https://github.com/antoineco/aco-tomcat",
   "source": "git://github.com/antoineco/aco-tomcat.git",

--- a/templates/common/server.xml/000_header.erb
+++ b/templates/common/server.xml/000_header.erb
@@ -5,5 +5,5 @@
 # ******************
 -->
 <Server<%- if @server_params_real and ! @server_params_real.empty? -%>
-  <%- @server_params_real.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%>
+  <%- @server_params_real.sort.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%>
 <%- end -%>>

--- a/templates/common/server.xml/010_listeners.erb
+++ b/templates/common/server.xml/010_listeners.erb
@@ -26,6 +26,6 @@
 <%- end -%>
 <%- if @listeners and ! @listeners.empty? -%>
   <%- [@listeners].flatten.compact.each do |listener| -%>
-  <Listener<%- listener.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%> />
+  <Listener<%- listener.sort.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%> />
   <%- end -%>
 <%- end -%>

--- a/templates/common/server.xml/020_globalnamingresources.erb
+++ b/templates/common/server.xml/020_globalnamingresources.erb
@@ -10,11 +10,11 @@
 <%- end -%>
 <%- if @globalnaming_resources and ! @globalnaming_resources.empty? -%>
   <%- [@globalnaming_resources].flatten.compact.each do |resource| %>
-    <%- resource.each_pair do |attrib, value| -%>
-      <%- if attrib == resource.keys.first -%>
-    <Resource <%= attrib %>="<%= value %>"<% if attrib == resource.keys.last %> /><% end %>
+    <%- resource.sort.each_pair do |attrib, value| -%>
+      <%- if attrib == resource.keys.sort.first -%>
+    <Resource <%= attrib %>="<%= value %>"<% if attrib == resource.keys.sort.last %> /><% end %>
       <%- else -%>
-              <%= attrib %>="<%= value %>"<% if attrib == resource.keys.last %> /><% end %>
+              <%= attrib %>="<%= value %>"<% if attrib == resource.keys.sort.last %> /><% end %>
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/templates/common/server.xml/030_service.erb
+++ b/templates/common/server.xml/030_service.erb
@@ -1,4 +1,4 @@
 
   <Service<%- if @svc_params_real and ! @svc_params_real.empty? -%>
-    <%- @svc_params_real.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%>
+    <%- @svc_params_real.sort.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%>
   <%- end -%>>

--- a/templates/common/server.xml/040_threadpool_executor.erb
+++ b/templates/common/server.xml/040_threadpool_executor.erb
@@ -1,7 +1,7 @@
 
     <Executor name="<%= @threadpool_name %>"<% if @threadpool_params_real and ! @threadpool_params_real.empty? %>
-             <%- @threadpool_params_real.each_pair do |attrib, value| -%>
-              <%= attrib %>="<%= value %>"<% if attrib == @threadpool_params_real.keys.last %> /><% end %>
+             <%- @threadpool_params_real.sort.each_pair do |attrib, value| -%>
+              <%= attrib %>="<%= value %>"<% if attrib == @threadpool_params_real.keys.sort.last %> /><% end %>
              <%- end -%>
            <%- else -%>
  />

--- a/templates/common/server.xml/041_executors.erb
+++ b/templates/common/server.xml/041_executors.erb
@@ -1,9 +1,9 @@
 <%- [@executors].flatten.compact.each do |executor| %>
-  <%- executor.each_pair do |attrib, value| -%>
-    <%- if attrib == executor.keys.first -%>
-    <Executor <%= attrib %>="<%= value %>"<% if attrib == executor.keys.last %> /><% end %>
+  <%- executor.sort.each_pair do |attrib, value| -%>
+    <%- if attrib == executor.keys.sort.first -%>
+    <Executor <%= attrib %>="<%= value %>"<% if attrib == executor.keys.sort.last %> /><% end %>
     <%- else -%>
-              <%= attrib %>="<%= value %>"<% if attrib == executor.keys.last %> /><% end %>
+              <%= attrib %>="<%= value %>"<% if attrib == executor.keys.sort.last %> /><% end %>
     <%- end -%>
   <%- end -%>
 <%- end -%>

--- a/templates/common/server.xml/050_http_connector.erb
+++ b/templates/common/server.xml/050_http_connector.erb
@@ -1,7 +1,7 @@
 
     <Connector port="<%= @http_port %>"<% if @ssl_connector %> redirectPort="<%= @ssl_port %>"<% end %><% if @http_params_real and ! @http_params_real.empty? %>
-             <%- @http_params_real.each_pair do |attrib, value| -%>
-               <%= attrib %>="<%= value %>"<% if attrib == @http_params_real.keys.last %> /><% end %>
+             <%- @http_params_real.sort.each_pair do |attrib, value| -%>
+               <%= attrib %>="<%= value %>"<% if attrib == @http_params_real.keys.sort.last %> /><% end %>
              <%- end -%>
            <%- else -%>
  />

--- a/templates/common/server.xml/051_ssl_connector.erb
+++ b/templates/common/server.xml/051_ssl_connector.erb
@@ -1,7 +1,7 @@
 
     <Connector port="<%= @ssl_port %>" SSLEnabled="true" scheme="https" secure="true"<% if @ssl_params_real and ! @ssl_params_real.empty? %>
-             <%- @ssl_params_real.each_pair do |attrib, value| -%>
-               <%= attrib %>="<%= value %>"<% if attrib == @ssl_params_real.keys.last %> /><% end %>
+             <%- @ssl_params_real.sort.each_pair do |attrib, value| -%>
+               <%= attrib %>="<%= value %>"<% if attrib == @ssl_params_real.keys.sort.last %> /><% end %>
              <%- end -%>
            <%- else -%>
  />

--- a/templates/common/server.xml/052_ajp_connector.erb
+++ b/templates/common/server.xml/052_ajp_connector.erb
@@ -1,7 +1,7 @@
 
     <Connector port="<%= @ajp_port %>" protocol="<%= @ajp_protocol %>"<% if @ssl_connector %> redirectPort="<%= @ssl_port %>"<% end %><% if @ajp_params_real and ! @ajp_params_real.empty? %>
-             <%- @ajp_params_real.each_pair do |attrib, value| -%>
-               <%= attrib %>="<%= value %>"<% if attrib == @ajp_params_real.keys.last %> /><% end %>
+             <%- @ajp_params_real.sort.each_pair do |attrib, value| -%>
+               <%= attrib %>="<%= value %>"<% if attrib == @ajp_params_real.keys.sort.last %> /><% end %>
              <%- end -%>
            <%- else -%>
  />

--- a/templates/common/server.xml/053_connectors.erb
+++ b/templates/common/server.xml/053_connectors.erb
@@ -1,9 +1,9 @@
 <%- [@connectors].flatten.compact.each do |connector| %>
-  <%- connector.each_pair do |attrib, value| -%>
-    <%- if attrib == connector.keys.first -%>
-    <Connector <%= attrib %>="<%= value %>"<% if attrib == connector.keys.last %> /><% end %>
+  <%- connector.sort.each_pair do |attrib, value| -%>
+    <%- if attrib == connector.keys.sort.first -%>
+    <Connector <%= attrib %>="<%= value %>"<% if attrib == connector.keys.sort.last %> /><% end %>
     <%- else -%>
-               <%= attrib %>="<%= value %>"<% if attrib == connector.keys.last %> /><% end %>
+               <%= attrib %>="<%= value %>"<% if attrib == connector.keys.sort.last %> /><% end %>
     <%- end -%>
   <%- end -%>
 <%- end -%>

--- a/templates/common/server.xml/060_engine.erb
+++ b/templates/common/server.xml/060_engine.erb
@@ -1,4 +1,4 @@
 
     <Engine<%- if @engine_params_real and ! @engine_params_real.empty? -%>
-      <%- @engine_params_real.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%>
+      <%- @engine_params_real.sort.each_pair do |attrib, value| -%> <%= attrib %>="<%= value %>"<%- end -%>
     <%- end -%>>

--- a/templates/common/server.xml/080_realms.erb
+++ b/templates/common/server.xml/080_realms.erb
@@ -8,11 +8,11 @@
 <% end -%>
 <%- if @realms and ! @realms.empty? -%>
   <%- [@realms].flatten.compact.each do |realm| %>
-    <%- realm.each_pair do |attrib, value| -%>
-      <%- if attrib == realm.keys.first -%>
-<% if @lockout_realm %>  <% end %>      <Realm <%= attrib %>="<%= value %>"<% if attrib == realm.keys.last %> /><% end %>
+    <%- realm.sort.each_pair do |attrib, value| -%>
+      <%- if attrib == realm.keys.sort.first -%>
+<% if @lockout_realm %>  <% end %>      <Realm <%= attrib %>="<%= value %>"<% if attrib == realm.keys.sort.last %> /><% end %>
       <%- else -%>
-<% if @lockout_realm %>  <% end %>             <%= attrib %>="<%= value %>"<% if attrib == realm.keys.last %> /><% end %>
+<% if @lockout_realm %>  <% end %>             <%= attrib %>="<%= value %>"<% if attrib == realm.keys.sort.last %> /><% end %>
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/templates/common/server.xml/090_host.erb
+++ b/templates/common/server.xml/090_host.erb
@@ -1,7 +1,7 @@
 
       <Host name="<%= @host_name %>"<% if @host_params_real and ! @host_params_real.empty? %>
-             <%- @host_params_real.each_pair do |attrib, value| -%>
-            <%= attrib %>="<%= value %>"<% if attrib == @host_params_real.keys.last %>><% end %>
+             <%- @host_params_real.sort.each_pair do |attrib, value| -%>
+            <%= attrib %>="<%= value %>"<% if attrib == @host_params_real.keys.sort.last %>><% end %>
              <%- end -%>
            <%- else -%>
 >

--- a/templates/common/server.xml/100_valves.erb
+++ b/templates/common/server.xml/100_valves.erb
@@ -8,11 +8,11 @@
 <% end -%>
 <%- if @valves and ! @valves.empty? -%>
   <%- [@valves].flatten.compact.each do |valve| %>
-    <%- valve.each_pair do |attrib, value| -%>
-      <%- if attrib == valve.keys.first -%>
-        <Valve <%= attrib %>="<%= value %>"<% if attrib == valve.keys.last %> /><% end %>
+    <%- valve.sort.each_pair do |attrib, value| -%>
+      <%- if attrib == valve.keys.sort.first -%>
+        <Valve <%= attrib %>="<%= value %>"<% if attrib == valve.keys.sort.last %> /><% end %>
       <%- else -%>
-               <%= attrib %>="<%= value %>"<% if attrib == valve.keys.last %> /><% end %>
+               <%= attrib %>="<%= value %>"<% if attrib == valve.keys.sort.last %> /><% end %>
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/templates/common/setenv.erb
+++ b/templates/common/setenv.erb
@@ -49,7 +49,7 @@ SHUTDOWN_VERBOSE="<%= @shutdown_verbose %>"
 
 # Custom variables
 <%- if @custom_variables and ! @custom_variables.empty? -%>
-  <%- @custom_variables.each_pair do |attrib, value| -%>
+  <%- @custom_variables.sort.each_pair do |attrib, value| -%>
 <%= attrib %>="<%= value %>"
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Some files were being created as directories so I set those resources to be explicitly files.  Also in Ruby 1.8.7 the attribute hashes in the templates are unordered which is causing Puppet to change them during each run.  The attributes are now sorted in alphabetical order to prevent Puppet from detecting changes when there weren't any.
