### PR TITLE
Check if $::tomcat::log_path_real is defined

### DIFF
--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -59,12 +59,14 @@ class tomcat::install::archive {
     }
   }
 
-  file { $::tomcat::log_path_real:
-    ensure => directory,
-    path   => $::tomcat::log_path_real,
-    mode   => '0660',
-    alias  => 'tomcat logs directory',
-    tag    => 'tomcat_tree'
+  if !defined($::tomcat::log_path_real) {
+    file { $::tomcat::log_path_real:
+      ensure => directory,
+      path   => $::tomcat::log_path_real,
+      mode   => '0660',
+      alias  => 'tomcat logs directory',
+      tag    => 'tomcat_tree'
+    }
   }
 
   # default pid file directory


### PR DESCRIPTION
Check if the log directory is already defined so perms and ownership can be maintained elsewhere.
