### PR TITLE
Add systemd_service_type param

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ Whether the service should be running. Valid values are `stopped` and `running`.
 #####`service_enable`
 Whether to enable the tomcat service. Boolean value. Defaults to `true`.
 
+#####`systemd_service_type`
+The value for the systemd service type if applicable.
+
 #####`service_start`
 Optional override command for starting the service. Default depends on the platform.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@
 #   whether the service should be running (valid: 'stopped'|'running')
 # [*service_enable*]
 #   enable service (boolean)
+# [*systemd_service_type*]
+#   value for systemd service type
 # [*service_start*]
 #   override service startup command
 # [*service_stop*]
@@ -83,6 +85,7 @@ class tomcat (
   $service_name               = undef,
   $service_ensure             = 'running',
   $service_enable             = true,
+  $systemd_service_type       = undef,
   $service_start              = undef,
   $service_stop               = undef,
   $tomcat_user                = undef,
@@ -363,6 +366,23 @@ class tomcat (
     }
   } else {
     $config_path_real = $config_path
+  }
+
+  if $systemd_service_type == undef {
+    case $::tomcat::install_from {
+      'package' : {
+        if ($::operatingsystem == 'Fedora' and $::operatingsystemmajrelease < '20') {
+          $systemd_service_type_real = 'forking'
+        } else {
+          $systemd_service_type_real = 'simple'
+        }
+      }
+      default : {
+        $systemd_service_type_real = 'simple'
+      }
+    }
+  } else {
+    $systemd_service_type_real = $systemd_service_type
   }
 
   if $service_start == undef {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -16,6 +16,8 @@
 #   whether the service should be running (valid: 'stopped'|'running')
 # [*service_enable*]
 #   enable service (boolean)
+# [*systemd_service_type*]
+#   value for systemd service type
 # [*service_start*]
 #   override service startup command
 # [*service_stop*]
@@ -61,6 +63,7 @@ define tomcat::instance (
   $service_name               = undef,
   $service_ensure             = 'running',
   $service_enable             = true,
+  $systemd_service_type       = undef,
   $service_start              = undef,
   $service_stop               = undef,
   $tomcat_user                = $::tomcat::tomcat_user_real,
@@ -341,6 +344,23 @@ define tomcat::instance (
     }
   } else {
     $config_path_real = $config_path
+  }
+
+  if $systemd_service_type == undef {
+    case $::tomcat::install_from {
+      'package' : {
+        if ($::operatingsystem == 'Fedora' and $::operatingsystemmajrelease < '20') {
+          $systemd_service_type_real = 'forking'
+        } else {
+          $systemd_service_type_real = 'simple'
+        }
+      }
+      default : {
+        $systemd_service_type_real = 'simple'
+      }
+    }
+  } else {
+    $systemd_service_type_real = $systemd_service_type
   }
 
   if $service_start == undef {

--- a/templates/instance/systemd_unit_fedora.erb
+++ b/templates/instance/systemd_unit_fedora.erb
@@ -3,7 +3,7 @@ Description=Apache Tomcat Web Application Container
 After=syslog.target network.target
 
 [Service]
-Type=forking
+Type=<%= @systemd_service_type_real %>
 ExecStart=<%= @service_start_real %>
 ExecStop=<%= @service_stop_real %>
 SuccessExitStatus=143

--- a/templates/instance/systemd_unit_rhel.erb
+++ b/templates/instance/systemd_unit_rhel.erb
@@ -3,7 +3,7 @@ Description=Apache Tomcat Web Application Container
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=<%= @systemd_service_type_real %>
 EnvironmentFile=-<%= @config_path_real %>
 ExecStart=<%= @service_start_real %>
 ExecStop=<%= @service_stop_real %>

--- a/templates/instance/systemd_unit_suse.erb
+++ b/templates/instance/systemd_unit_suse.erb
@@ -3,7 +3,7 @@ Description=Apache Tomcat Web Application Container
 After=network.target
 
 [Service]
-Type=simple
+Type=<%= @systemd_service_type_real %>
 EnvironmentFile=-<%= @config_path_real %>
 User=<%= @tomcat_user %>
 Group=<%= @tomcat_group %>


### PR DESCRIPTION
This PR adds the `systemd_service_type` param to both `tomcat` and `tomcat::instance`.  It has sane defaults for supported operating systems and archive/package installation types.

Fixes #36
