### PR TITLE
Support for Amazon Linux 2015.09

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,18 @@ class tomcat::params {
           }
           $systemd = true
         }
+        'Amazon' : {
+          case $::operatingsystemrelease {
+            '2015.09'    : {
+              $package_name = 'tomcat7'
+              $version = '7.0.62-1.10.amzn1'
+              $systemd = false
+            }
+            default : {
+              fail("Unsupported OS version ${::operatingsystemmajrelease}")
+            }
+          }
+        }
         default  : {
           case $::operatingsystemmajrelease {
             '7'     : {


### PR DESCRIPTION
This adds support for Amazon LInux 2015.09 which is of the RedHat family, works just fine.
