### PR TITLE
Manage user roles (Issue #29)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,10 @@ class tomcat::params {
       case $::operatingsystem {
         'Fedora' : {
           case $::operatingsystemmajrelease {
+            '24'    : {
+              $version = '1:8.0.32-4.fc24'
+              $package_name = 'tomcat'
+            }
             '23'    : {
               $version = '1:8.0.32-5.fc23'
               $package_name = 'tomcat'
@@ -21,17 +25,12 @@ class tomcat::params {
           $systemd = true
         }
         'Amazon' : {
-          case $::operatingsystemmajrelease {
-            '2015'  : {
-              $version = '8.0.23-1.54.amzn1'
-              $package_name = 'tomcat8'
-              # $version = '7.0.62-1.10.amzn1'
-              # $package_name = 'tomcat7'
-            }
-            default : {
-              fail("Unsupported OS version ${::operatingsystemrelease}")
-            }
-          }
+          $version = '8.0.32-1.59.amzn1'
+          $package_name = 'tomcat8'
+          # $version = '7.0.68-1.15.amzn1'
+          # $package_name = 'tomcat7'
+          # $version = '6.0.45-1.4.amzn1'
+          # $package_name = 'tomcat6'
           $systemd = false
         }
         default  : {
@@ -42,7 +41,7 @@ class tomcat::params {
               $systemd = true
             }
             '6'     : {
-              $version = '6.0.24-94.el6_7'
+              $version = '6.0.24-95.el6'
               $package_name = 'tomcat6'
               # = epel repo =
               # $version = '7.0.33-4.el6'
@@ -130,14 +129,14 @@ class tomcat::params {
             '8'     : {
               $version = '8.0.14-1+deb8u1'
               $package_name = 'tomcat8'
-              # $version = '7.0.56-3+deb8u1'
+              # $version = '7.0.56-3+deb8u2'
               # $package_name = 'tomcat7'
             }
             # wheezy
             '7'     : {
-              $version = '7.0.28-4+deb7u3'
+              $version = '7.0.28-4+deb7u4'
               $package_name = 'tomcat7'
-              # $version = '6.0.35-6+deb7u1'
+              # $version = '6.0.45+dfsg-1~deb7u1'
               # $package_name = 'tomcat6'
             }
             default : {
@@ -149,16 +148,16 @@ class tomcat::params {
           case $::operatingsystemrelease {
             # xenial
             '16.04' : {
-              $version = '8.0.32-1ubuntu1'
+              $version = '8.0.32-1ubuntu1.1'
               $package_name = 'tomcat8'
-              # $version = '7.0.68-1'
+              # $version = '7.0.68-1ubuntu0.1'
               # $package_name = 'tomcat7'
             }
             # wily
             '15.10' : {
               $version = '8.0.26-1'
               $package_name = 'tomcat8'
-              # $version = '7.0.64-1'
+              # $version = '7.0.64-1ubuntu0.3'
               # $package_name = 'tomcat7'
             }
             # vivid
@@ -179,7 +178,7 @@ class tomcat::params {
             }
             # trusty
             '14.04' : {
-              $version = '7.0.52-1ubuntu0.3'
+              $version = '7.0.52-1ubuntu0.6'
               $package_name = 'tomcat7'
               # $version = '6.0.39-1'
               # $package_name = 'tomcat6'

--- a/manifests/userdb_entry.pp
+++ b/manifests/userdb_entry.pp
@@ -1,8 +1,7 @@
-# == Define: tomcat::userdb_entry
-#
 define tomcat::userdb_entry (
-  $username,
-  $password,
+  $add_roles = 'false',
+  $username = undef,
+  $password = undef,
   $roles,
   $database = 'main UserDatabase') {
   # The base class must be included first
@@ -10,16 +9,22 @@ define tomcat::userdb_entry (
     fail('You must include the tomcat base class before using any tomcat defined resources')
   }
 
-  # parameters validation
-  validate_array($roles)
-  validate_string($username, $password)
-
-  $roles_string = join($roles, ',')
-
-  # add formated fragment
-  concat::fragment { "UserDatabase entry (${title})":
+  if $add_roles == 'true' {
+    validate_array($roles)
+    concat::fragment { "UserDatabase entry (${title})":
+      target  => $database,
+      content => template("${module_name}/common/UserDatabase_role_entry.erb"),
+      order   => 2
+    }
+  }
+  elsif $add_roles == 'false' {
+    validate_array($roles)
+    validate_string($username, $password)
+    $roles_string = join($roles, ',')
+    concat::fragment { "UserDatabase entry (${title})":
     target  => $database,
     content => template("${module_name}/common/UserDatabase_entry.erb"),
-    order   => 2
+    order   => 3
+    }
   }
 }

--- a/manifests/userdb_entry.pp
+++ b/manifests/userdb_entry.pp
@@ -22,9 +22,9 @@ define tomcat::userdb_entry (
     validate_string($username, $password)
     $roles_string = join($roles, ',')
     concat::fragment { "UserDatabase entry (${title})":
-    target  => $database,
-    content => template("${module_name}/common/UserDatabase_entry.erb"),
-    order   => 3
+      target  => $database,
+      content => template("${module_name}/common/UserDatabase_entry.erb"),
+      order   => 3
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -59,14 +59,16 @@
       "operatingsystem": "Amazon",
       "operatingsystemrelease": [
         "2015.03",
-        "2015.09"
+        "2015.09",
+        "2016.03"
       ]
     },
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
         "22",
-        "23"
+        "23",
+        "24"
       ]
     },
     {

--- a/templates/common/UserDatabase_role_entry.erb
+++ b/templates/common/UserDatabase_role_entry.erb
@@ -1,0 +1,2 @@
+<% @roles.each do |newrole| -%>  <role rolename="<%= newrole -%>"/>
+<% end -%>


### PR DESCRIPTION
I introduced a new parameter called add_roles in userdb_entry.pp. If this parameter is set to true you can add new roles instead of users to tomcat-users.xml. A new template (UserDatabase_role_entry.erb) adds the roles to the given userdatabase file. 

```
tomcat::userdb_entry { 'newRoles':
  database => 'main UserDatabase',
  add_roles => 'true'
  roles    => ['newRole1', 'newRole2']
}
```
