### PR TITLE
updates to cluster config and support for engine scoped valves

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,9 @@ Whether to enable the [Access Log Valve](http://tomcat.apache.org/tomcat-8.0-doc
 #####`valves`
 An array of custom `Valve` entries to be added to the `Host` container. Each entry is to be supplied as a hash of attributes/values for the `Valve` XML node. See [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) for the list of possible attributes.
 
+#####`engine_valves`
+An array of custom `Valve` entries to be added to the `Engine` container. Each entry is to be supplied as a hash of attributes/values for the `Valve` XML node. See [Valve](http://tomcat.apache.org/tomcat-8.0-doc/config/valve.html) for the list of possible attributes.
+
 #####`globalnaming_environments`
 An array of `Environment` entries to be added to the `GlobalNamingResources` component. Each entry is to be supplied as a hash of attributes/values for the `Environment` XML node. See [Global Resources](http://tomcat.apache.org/tomcat-8.0-doc/config/globalresources.html#Environment_Entries) for the list of possible attributes.
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Whether the service should be running. Valid values are `stopped` and `running`.
 Whether to enable the Tomcat service. Boolean value. Defaults to `true`.
 
 #####`systemd_service_type`
-The value for the systemd service type if applicable.
+The value for the systemd service type if applicable. Defaults to 'simple' for install_from = package, 'forking' for install_from = archive.
 
 #####`service_start`
 Optional override command for starting the service. Default depends on the platform.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,7 @@ class tomcat::config {
   $cluster_receiver_address = $::tomcat::cluster_receiver_address
   $cluster_receiver_port = $::tomcat::cluster_receiver_port
   $cluster_farm_deployer = $::tomcat::cluster_farm_deployer
+  $cluster_parent_real = $::tomcat::cluster_parent_real
   $cluster_farm_deployer_watchdir = $::tomcat::cluster_farm_deployer_watchdir
   $cluster_farm_deployer_watch_enabled = $::tomcat::cluster_farm_deployer_watch_enabled
   $combined_realm = $::tomcat::combined_realm
@@ -238,8 +239,9 @@ class tomcat::config {
   # - $cluster_membership_domain
   # - $cluster_receiver_address
   if $use_simpletcpcluster {
+    $cluster_order = $cluster_parent_real ? { 'host' => 95, default => 70}
     concat::fragment { 'server.xml cluster':
-      order   => 70,
+      order   => $cluster_order,
       content => template("${module_name}/common/server.xml/070_cluster.erb"),
       target  => 'tomcat server configuration'
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,10 @@ class tomcat::config {
   $cluster_membership_port = $::tomcat::cluster_membership_port
   $cluster_membership_domain = $::tomcat::cluster_membership_domain
   $cluster_receiver_address = $::tomcat::cluster_receiver_address
+  $cluster_receiver_port = $::tomcat::cluster_receiver_port
+  $cluster_farm_deployer = $::tomcat::cluster_farm_deployer
+  $cluster_farm_deployer_watchdir = $::tomcat::cluster_farm_deployer_watchdir
+  $cluster_farm_deployer_watch_enabled = $::tomcat::cluster_farm_deployer_watch_enabled
   $combined_realm = $::tomcat::combined_realm
   $lockout_realm = $::tomcat::lockout_realm
   $userdatabase_realm = $::tomcat::userdatabase_realm

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,12 +41,14 @@ class tomcat::config {
   $host_params_real = $::tomcat::host_params_real
   $use_simpletcpcluster = $::tomcat::use_simpletcpcluster
   $cluster_membership_port = $::tomcat::cluster_membership_port
+  $cluster_membership_bind_address = $::tomcat::cluster_membership_bind_address
   $cluster_membership_domain = $::tomcat::cluster_membership_domain
   $cluster_receiver_address = $::tomcat::cluster_receiver_address
   $cluster_receiver_port = $::tomcat::cluster_receiver_port
   $cluster_farm_deployer = $::tomcat::cluster_farm_deployer
   $cluster_parent_real = $::tomcat::cluster_parent_real
   $cluster_farm_deployer_watchdir = $::tomcat::cluster_farm_deployer_watchdir
+  $cluster_farm_deployer_deploydir = $::tomcat::cluster_farm_deployer_deploydir
   $cluster_farm_deployer_watch_enabled = $::tomcat::cluster_farm_deployer_watch_enabled
   $combined_realm = $::tomcat::combined_realm
   $lockout_realm = $::tomcat::lockout_realm
@@ -367,7 +369,7 @@ class tomcat::config {
   concat::fragment { 'main UserDatabase footer':
     target  => 'main UserDatabase',
     content => template("${module_name}/common/UserDatabase_footer.erb"),
-    order   => 4
+    order   => 3
   }
 
   # configure authorized access

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,7 @@ class tomcat::config {
   $singlesignon_valve = $::tomcat::singlesignon_valve
   $accesslog_valve = $::tomcat::accesslog_valve
   $valves = $::tomcat::valves
+  $engine_valves = $::tomcat::engine_valves
   $globalnaming_environments = $::tomcat::globalnaming_environments
   $globalnaming_resources = $::tomcat::globalnaming_resources
   $context_params = $::tomcat::context_params
@@ -219,6 +220,16 @@ class tomcat::config {
     order   => 60,
     content => template("${module_name}/common/server.xml/060_engine.erb"),
     target  => 'tomcat server configuration'
+  }
+
+  # Template uses:
+  # - $engine_valves
+  if ($engine_valves and $engine_valves != []) {
+    concat::fragment { 'server.xml engine valves':
+      order   => 65,
+      content => template("${module_name}/common/server.xml/065_engine_valves.erb"),
+      target  => 'tomcat server configuration'
+    }
   }
 
   # Template uses:

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -41,4 +41,20 @@ class tomcat::firewall {
       action => 'accept'
     }
   }
+
+  #cluster
+  if $::tomcat::use_simpletcpcluster {
+    firewall { "${::tomcat::cluster_receiver_port} accept - tomcat":
+      dport  => $::tomcat::cluster_receiver_port,
+      proto  => 'tcp',
+      action => 'accept'
+    }
+    firewall { "${::tomcat::cluster_membership_port} accept - tomcat":
+      sport       => $::tomcat::cluster_membership_port,
+      dport       => $::tomcat::cluster_membership_port,
+      proto       => 'udp',
+      action      => 'accept',
+      destination => '228.0.0.4'
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -242,10 +242,12 @@ class tomcat (
   $host_unpackwars            = undef,
   $host_params                = {},
   #..................................................................................
-  # valves
+  # host valves
   $singlesignon_valve         = false,
   $accesslog_valve            = true,
   $valves                     = [],
+  # engine valves
+  $engine_valves              = [],
   #..................................................................................
   # misc
   $globalnaming_environments  = [],
@@ -295,7 +297,7 @@ class tomcat (
   validate_re($install_from, '^(package|archive)$', '$install_from must be either \'package\' or \'archive\'')
   validate_re($version, '^(?:[0-9]{1,2}:)?[0-9]\.[0-9]\.[0-9]{1,2}(?:-.*)?$', 'incorrect tomcat version number')
   validate_re($service_ensure, '^(stopped|running)$', '$service_ensure must be either \'stopped\', or \'running\'')
-  validate_array($listeners, $executors, $connectors, $realms, $valves, $globalnaming_environments, $globalnaming_resources, $context_watchedresources, $context_parameters, $context_environments, $context_listeners, $context_valves, $context_resourcedefs, $context_resourcelinks, $catalina_opts, $java_opts, $jpda_opts)
+  validate_array($listeners, $executors, $connectors, $realms, $valves, $engine_valves, $globalnaming_environments, $globalnaming_resources, $context_watchedresources, $context_parameters, $context_environments, $context_listeners, $context_valves, $context_resourcedefs, $context_resourcelinks, $catalina_opts, $java_opts, $jpda_opts)
   validate_hash($server_params, $svc_params, $threadpool_params, $http_params, $ssl_params, $ajp_params, $engine_params, $host_params, $context_params, $context_loader, $context_manager, $context_realm, $context_resources, $custom_variables, $tomcat_users, $tomcat_roles)
   validate_bool($checksum_verify)
   validate_re($checksum_type, '^(none|md5|sha1|sha2|sh256|sha384|sha512)$', 'The checksum type needs to be one of the following: none|md5|sha1|sha2|sh256|sha384|sha512')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,6 +223,8 @@ class tomcat (
   $cluster_receiver_address   = undef,
   $cluster_receiver_port      = '4000',
   $cluster_farm_deployer      = false,
+  #cluster_parent can be engine or host, must be host if using farm deployer
+  $cluster_parent             = undef,
   # This directory is currently not managed by this module
   $cluster_farm_deployer_watchdir = 'deploy',
   $cluster_farm_deployer_watch_enabled = true,
@@ -304,6 +306,17 @@ class tomcat (
 
   if $checksum_verify and !$checksum {
     fail('Checksum verification requires \'checksum\' variable to be set')
+  }
+
+  # cluster can live in engine or host, engine was original default, host is required if using farm deployer
+  if $cluster_parent {
+    validate_re($cluster_parent, '^(engine|host)$', 'cluster_parent must be host or engine')
+    if $cluster_farm_deployer and $cluster_parent == 'engine' {
+      fail('Farm deployer cannot be used with cluster_parent=engine')
+    }
+    $cluster_parent_real = $cluster_parent
+  } else {
+    $cluster_parent_real = $cluster_farm_deployer ? { true => 'host', default => 'engine' }
   }
 
   # split version string

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -450,7 +450,12 @@ class tomcat (
       true    => 'jpda start',
       default => 'start'
     }
-    $service_start_real = "${catalina_home_real}/bin/catalina.sh ${start_cmd}"
+    # catalina.sh in archive for 7,8,8.5 takes -security option to enable security manager
+    $security_arg = $security_manager ? {
+      true    => ' -security',
+      default => ''
+    }
+    $service_start_real = "${catalina_home_real}/bin/catalina.sh ${start_cmd}${security_arg}"
   } else {
     $service_start_real = $service_start
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,6 +221,11 @@ class tomcat (
   $cluster_membership_port    = '45565',
   $cluster_membership_domain  = 'tccluster',
   $cluster_receiver_address   = undef,
+  $cluster_receiver_port      = '4000',
+  $cluster_farm_deployer      = false,
+  # This directory is currently not managed by this module
+  $cluster_farm_deployer_watchdir = 'deploy',
+  $cluster_farm_deployer_watch_enabled = true,
   #..................................................................................
   # realms
   $combined_realm             = false,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -209,10 +209,12 @@ define tomcat::instance (
   $host_unpackwars            = undef,
   $host_params                = {},
   #..................................................................................
-  # valves
+  # host valves
   $singlesignon_valve         = false,
   $accesslog_valve            = true,
   $valves                     = [],
+  # engine valves
+  $engine_valves              = [],
   #..................................................................................
   # misc
   $globalnaming_environments  = [],
@@ -270,7 +272,7 @@ define tomcat::instance (
   # parameters validation
   validate_re($version, '^(?:[0-9]{1,2}:)?[0-9]\.[0-9]\.[0-9]{1,2}(?:-.*)?$', 'incorrect tomcat version number')
   validate_re($service_ensure, '^(stopped|running)$', '$service_ensure must be either \'stopped\', or \'running\'')
-  validate_array($listeners, $executors, $connectors, $realms, $valves, $globalnaming_environments, $globalnaming_resources, $context_watchedresources, $context_parameters, $context_environments, $context_listeners, $context_valves, $context_resourcedefs, $context_resourcelinks, $catalina_opts, $java_opts, $jpda_opts)
+  validate_array($listeners, $executors, $connectors, $realms, $valves, $engine_valves, $globalnaming_environments, $globalnaming_resources, $context_watchedresources, $context_parameters, $context_environments, $context_listeners, $context_valves, $context_resourcedefs, $context_resourcelinks, $catalina_opts, $java_opts, $jpda_opts)
   validate_hash($server_params, $svc_params, $threadpool_params, $http_params, $ssl_params, $ajp_params, $engine_params, $host_params, $context_params, $context_loader, $context_manager, $context_realm, $context_resources, $custom_variables, $tomcat_users, $tomcat_roles)
   validate_bool($checksum_verify)
   validate_re($checksum_type, '^(none|md5|sha1|sha2|sh256|sha384|sha512)$', 'The checksum type needs to be one of the following: none|md5|sha1|sha2|sh256|sha384|sha512')
@@ -914,6 +916,16 @@ define tomcat::instance (
     order   => 60,
     content => template("${module_name}/common/server.xml/060_engine.erb"),
     target  => "instance ${name} server configuration"
+  }
+
+  # Template uses:
+  # - $engine_valves
+  if ($engine_valves and $engine_valves != []) {
+    concat::fragment { "instance ${name} server.xml engine valves":
+      order   => 65,
+      content => template("${module_name}/common/server.xml/065_engine_valves.erb"),
+      target  => "instance ${name} server configuration"
+    }
   }
 
   # Template uses:

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -424,7 +424,13 @@ define tomcat::instance (
           true    => 'jpda start',
           default => 'start'
         }
-        $service_start_real = "${catalina_home_real}/bin/catalina.sh ${start_cmd}"
+        # catalina.sh in archive for 7,8,8.5 takes -security option to enable security manager
+        # module currently does not put catalina.policy in ${catalina_base}/conf folder  
+        $security_arg = $security_manager ? {
+          true    => ' -security',
+          default => ''
+        }
+        $service_start_real = "${catalina_home_real}/bin/catalina.sh ${start_cmd}${security_arg}"
       }
     }
   } else {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -186,14 +186,18 @@ define tomcat::instance (
   # cluster (experimental)
   $use_simpletcpcluster       = false,
   $cluster_membership_port    = '45565',
+  # use cluster_membership_bind_address to specify which NIC is usd for multicast
+  # if this causes crash, try starting tomcat without both ipv4 & ipv6, e.g. -Djava.net.preferIPv4Stack=true
+  $cluster_membership_bind_address = undef,
   $cluster_membership_domain  = 'tccluster',
   $cluster_receiver_address   = undef,
   $cluster_receiver_port      = '4000',
   $cluster_farm_deployer      = false,
   #cluster_parent can be engine or host, must be host if using farm deployer
   $cluster_parent             = undef,
+  $cluster_farm_deployer_watchdir  = undef,
   # This directory is currently not managed by this module
-  $cluster_farm_deployer_watchdir = 'deploy',
+  $cluster_farm_deployer_deploydir = undef,
   $cluster_farm_deployer_watch_enabled = true,
   #..................................................................................
   # realms
@@ -281,17 +285,6 @@ define tomcat::instance (
 
   if $checksum_verify and !$checksum {
     fail('Checksum verification requires \'checksum\' variable to be set')
-  }
-
-  # cluster can live in engine or host, engine was original default, host is required if using farm deployer
-  if $cluster_parent {
-    validate_re($cluster_parent, '^(engine|host)$', 'cluster_parent must be host or engine')
-    if $cluster_farm_deployer and $cluster_parent == 'engine' {
-      fail('Farm deployer cannot be used with cluster_parent=engine')
-    }
-    $cluster_parent_real = $cluster_parent
-  } else {
-    $cluster_parent_real = $cluster_farm_deployer ? { true => 'host', default => 'engine' }
   }
 
   # multi-version installation only supported with archive installation
@@ -403,7 +396,11 @@ define tomcat::instance (
   }
 
   if $systemd_service_type == undef {
-    $systemd_service_type_real = 'simple'
+    if $::tomcat::install_from == 'archive' {
+      $systemd_service_type_real = 'forking'
+    } else {
+      $systemd_service_type_real = 'simple'
+    }
   } else {
     $systemd_service_type_real = $systemd_service_type
   }
@@ -424,7 +421,7 @@ define tomcat::instance (
           true    => 'jpda start',
           default => 'start'
         }
-        # catalina.sh in archive for 7,8,8.5 takes -security option to enable security manager
+        # catalina.sh in archive takes -security option to enable security manager
         # module currently does not put catalina.policy in ${catalina_base}/conf folder  
         $security_arg = $security_manager ? {
           true    => ' -security',
@@ -790,6 +787,21 @@ define tomcat::instance (
       }
     }
   }
+
+  # cluster can live in engine or host, engine was original default, host is required if using farm deployer
+  if $cluster_parent {
+    validate_re($cluster_parent, '^(engine|host)$', 'cluster_parent must be host or engine')
+    if $cluster_farm_deployer and $cluster_parent == 'engine' {
+      fail('Farm deployer cannot be used with cluster_parent=engine')
+    }
+    $cluster_parent_real = $cluster_parent
+  } else {
+    $cluster_parent_real = $cluster_farm_deployer ? { true => 'host', default => 'engine' }
+  }
+  # default name for watchdir is "deploy" b/c you put WAR there to deploy it
+  # deploydir (typically webapps) is where files are deployed to
+  $cluster_farm_deployer_watchdir_real = pick($cluster_farm_deployer_watchdir,"${catalina_base_real}/deploy")
+  $cluster_farm_deployer_deploydir_real = pick($cluster_farm_deployer_deploydir, "${catalina_base_real}/webapps")
 
   service { $service_name_real:
     ensure  => $service_ensure,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -188,6 +188,11 @@ define tomcat::instance (
   $cluster_membership_port    = '45565',
   $cluster_membership_domain  = 'tccluster',
   $cluster_receiver_address   = undef,
+  $cluster_receiver_port      = '4000',
+  $cluster_farm_deployer      = false,
+  # This directory is currently not managed by this module
+  $cluster_farm_deployer_watchdir = 'deploy',
+  $cluster_farm_deployer_watch_enabled = true,
   #..................................................................................
   # realms
   $combined_realm             = false,

--- a/templates/common/server.xml/065_engine_valves.erb
+++ b/templates/common/server.xml/065_engine_valves.erb
@@ -1,0 +1,11 @@
+<%- if @engine_valves and ! @engine_valves.empty? -%>
+  <%- [@engine_valves].flatten.compact.each do |valve| %>
+    <%- valve.each_pair do |attrib, value| -%>
+      <%- if attrib == valve.keys.first -%>
+        <Valve <%= attrib %>=<%= "#{value}".encode(:xml => :attr) %><% if attrib == valve.keys.last %> /><% end %>
+      <%- else -%>
+               <%= attrib %>=<%= "#{value}".encode(:xml => :attr) %><% if attrib == valve.keys.last %> /><% end %>
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
+<%- end -%>

--- a/templates/common/server.xml/070_cluster.erb
+++ b/templates/common/server.xml/070_cluster.erb
@@ -33,6 +33,8 @@
                     watchDir="<%= @cluster_farm_deployer_watchdir %>"
                     watchEnabled="<%= @cluster_farm_deployer_watch_enabled %>"/>
 <%- end -%>
+<%- if scope.function_versioncmp([@maj_version, '8']) < 0 -%>
          <ClusterListener className="org.apache.catalina.ha.session.JvmRouteSessionIDBinderListener"/>
+<%- end -%>
          <ClusterListener className="org.apache.catalina.ha.session.ClusterSessionListener"/>
       </Cluster>

--- a/templates/common/server.xml/070_cluster.erb
+++ b/templates/common/server.xml/070_cluster.erb
@@ -13,7 +13,7 @@
                         dropTime="3000"/>
             <Receiver className="org.apache.catalina.tribes.transport.nio.NioReceiver"
                          address="<%= @cluster_receiver_address %>"
-                         port="4000"
+                         port="<%= @cluster_receiver_port %>"
                          autoBind="100"
                          selectorTimeout="5000"
                          maxThreads="6"/>
@@ -26,6 +26,13 @@
          <Valve className="org.apache.catalina.ha.tcp.ReplicationValve"
                 filter=".*\.gif;.*\.js;.*\.jpg;.*\.png;.*\.css;.*\.txt;"/>
          <Valve className="org.apache.catalina.ha.session.JvmRouteBinderValve"/>
+<%- if @cluster_farm_deployer -%>
+         <Deployer className="org.apache.catalina.ha.deploy.FarmWarDeployer"
+                    tempDir="<%= @catalina_tmpdir_real %>"
+                    deployDir="webapps"
+                    watchDir="<%= @cluster_farm_deployer_watchdir %>"
+                    watchEnabled="<%= @cluster_farm_deployer_watch_enabled %>"/>
+<%- end -%>
          <ClusterListener className="org.apache.catalina.ha.session.JvmRouteSessionIDBinderListener"/>
          <ClusterListener className="org.apache.catalina.ha.session.ClusterSessionListener"/>
       </Cluster>

--- a/templates/common/server.xml/070_cluster.erb
+++ b/templates/common/server.xml/070_cluster.erb
@@ -7,6 +7,9 @@
          <Channel className="org.apache.catalina.tribes.group.GroupChannel">
             <Membership className="org.apache.catalina.tribes.membership.McastService"
                         address="228.0.0.4"
+<%- if @cluster_membership_bind_address -%>
+                        bind="<%= @cluster_membership_bind_address %>"
+<%- end -%>
                         port="<%= @cluster_membership_port %>"
                         domain="<%= @cluster_membership_domain %>"
                         frequency="500"
@@ -29,8 +32,8 @@
 <%- if @cluster_farm_deployer -%>
          <Deployer className="org.apache.catalina.ha.deploy.FarmWarDeployer"
                     tempDir="<%= @catalina_tmpdir_real %>"
-                    deployDir="webapps"
-                    watchDir="<%= @cluster_farm_deployer_watchdir %>"
+                    deployDir="<%= @cluster_farm_deployer_deploydir_real %>"
+                    watchDir="<%= @cluster_farm_deployer_watchdir_real %>"
                     watchEnabled="<%= @cluster_farm_deployer_watch_enabled %>"/>
 <%- end -%>
 <%- if scope.function_versioncmp([@maj_version, '8']) < 0 -%>


### PR DESCRIPTION
The cluster updates include making the receiver port configurable and allowing a farm deployer to be optionally added to the cluster (defaults to false). Farm deployers let you drop a war in the deploy directory and the war gets pushed out to the cluster. If you remove war from deploy folder it gets undeployed. I have usually put the deploy folder in the catalina base for an instance but I have left it unmanaged by this module. 

This also adds support for valves at the engine scope (existing server.xml valves are in host scope). Examples of valves used at engine scope are:

```
<Engine name="Catalina" defaultHost="localhost">
  <Valve className="org.apache.catalina.valves.SSLValve"
     sslClientCertHeader="ssl_client_cert" />

  <Valve className="org.apache.catalina.valves.RemoteIpValve"
    protocolHeader="x-forwarded-proto"
    remoteIpHeader="x-forwarded-for" />
```

I also updated the concat dependency to allow concat > 2.0. I am using concat 2.2 and it seems to be working fine. 
