### PR TITLE
Add support for defining users and roles in hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     * [Define: tomcat::instance](#define-tomcatinstance)
     * [Common parameters](#common-parameters)
     * [Define: tomcat::userdb_entry](#define-tomcatuserdb_entry)
+    * [Define: tomcat::userdb_role_entry](#define-tomcatuserdb_role_entry)
     * [Define: tomcat::context](#define-tomcatcontext)
 5. [Testing - How to run the included spec tests](#testing)
 6. [Contributors](#contributors)
@@ -116,7 +117,6 @@ Add an additional admin for the manager
 ```puppet
 tomcat::userdb_entry { 'foo':
   database => 'main UserDatabase',
-  username => 'foo',
   password => 'bar',
   roles    => ['manager-gui', 'manager-script']
 }
@@ -375,6 +375,12 @@ Admin user name. Defaults to `tomcatadmin`.
 #####`admin_password`
 Admin user password. Defaults to `password`.
 
+#####`tomcat_users`
+Optional hash containing UserDatabase user entries. See [tomcat::userdb_entry](#define-tomcatuserdb_entry). Defaults to an empty hash.
+
+#####`tomcat_roles`
+Optional hash containing UserDatabase role entries. See [tomcat::userdb_role_entry](#define-tomcatuserdb_role_entry). Defaults to an empty hash.
+
 **Server configuration**
 
 #####`server_control_port`
@@ -578,7 +584,7 @@ Where to get log4j's configuration from. A [sample file](https://raw.githubuserc
 
 ####Define: `tomcat::userdb_entry`
 
-Create Tomcat UserDatabase entries
+Create Tomcat UserDatabase user entries. For creating a tomcat::userdb_entry using hiera, see parameter tomcat_users.
 
 **Parameters within `tomcat::userdb_entry`:**
 
@@ -586,13 +592,25 @@ Create Tomcat UserDatabase entries
 Which database file the entry should be added to. `main UserDatabase` (global) / `instance ${name} UserDatabase` (instance)
 
 #####`username`
-User name (string)
+User name (string). Optional, $name of the tomcat::userdb_entry resource is used as the username by default.
 
 #####`password`
 User password (string)
 
 #####`roles`
 User roles (array)
+
+####Define: `tomcat::userdb_role_entry`
+
+Create Tomcat UserDatabase role entries. For creating a tomcat::userdb_role_entry using hiera, see parameter tomcat_roles.
+
+**Parameters within `tomcat::userdb_role_entry`:**
+
+#####`database`
+Which database file the entry should be added to. `main UserDatabase` (global) / `instance ${name} UserDatabase` (instance)
+
+#####`role`
+Role name (string)
 
 ####Define: `tomcat::context`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -348,7 +348,7 @@ class tomcat::config {
   concat::fragment { 'main UserDatabase footer':
     target  => 'main UserDatabase',
     content => template("${module_name}/common/UserDatabase_footer.erb"),
-    order   => 3
+    order   => 4
   }
 
   # configure authorized access

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,8 @@ class tomcat::config {
   $maj_version = $::tomcat::maj_version
   $tomcat_user = $::tomcat::tomcat_user_real
   $tomcat_group = $::tomcat::tomcat_group_real
+  $tomcat_users = $::tomcat::tomcat_users
+  $tomcat_roles = $::tomcat::tomcat_roles
   $server_params_real = $::tomcat::server_params_real
   $jmx_listener = $::tomcat::jmx_listener
   $jmx_registry_port = $::tomcat::jmx_registry_port
@@ -360,4 +362,8 @@ class tomcat::config {
       roles    => ['manager-gui', 'manager-script', 'admin-gui', 'admin-script']
     }
   }
+
+  # Configure users and roles defined in $tomcat_users and $tomcat_roles
+  create_resources('::tomcat::userdb_entry', $tomcat_users, {})
+  create_resources('::tomcat::userdb_role_entry', $tomcat_roles, {})
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,10 @@
 #   admin user name
 # [*admin_password*]
 #   admin user password
+# [*tomcat_users*]
+#   hash containing user definitions
+# [*tomcat_roles*]
+#   hash containing role definitions
 # [*checksum_verify*]
 #   verify the checksum if tomcat is installed from an archive (boolean)
 # [*checksum_type*]
@@ -126,6 +130,8 @@ class tomcat (
   $create_default_admin       = false,
   $admin_user                 = 'tomcatadmin',
   $admin_password             = 'password',
+  $tomcat_users               = {},
+  $tomcat_roles               = {},
   #..................................................................................
   # logging
   #..................................................................................
@@ -285,13 +291,16 @@ class tomcat (
   validate_re($version, '^(?:[0-9]{1,2}:)?[0-9]\.[0-9]\.[0-9]{1,2}(?:-.*)?$', 'incorrect tomcat version number')
   validate_re($service_ensure, '^(stopped|running)$', '$service_ensure must be either \'stopped\', or \'running\'')
   validate_array($listeners, $executors, $connectors, $realms, $valves, $globalnaming_environments, $globalnaming_resources, $context_watchedresources, $context_parameters, $context_environments, $context_listeners, $context_valves, $context_resourcedefs, $context_resourcelinks, $catalina_opts, $java_opts, $jpda_opts)
-  validate_hash($server_params, $svc_params, $threadpool_params, $http_params, $ssl_params, $ajp_params, $engine_params, $host_params, $context_params, $context_loader, $context_manager, $context_realm, $context_resources, $custom_variables)
+  validate_hash($server_params, $svc_params, $threadpool_params, $http_params, $ssl_params, $ajp_params, $engine_params, $host_params, $context_params, $context_loader, $context_manager, $context_realm, $context_resources, $custom_variables, $tomcat_users, $tomcat_roles)
   validate_bool($checksum_verify)
   validate_re($checksum_type, '^(none|md5|sha1|sha2|sh256|sha384|sha512)$', 'The checksum type needs to be one of the following: none|md5|sha1|sha2|sh256|sha384|sha512')
 
   if $checksum_verify and !$checksum {
     fail('Checksum verification requires \'checksum\' variable to be set')
   }
+
+  create_resources('::tomcat::userdb_entry', $tomcat_users, {})
+  create_resources('::tomcat::userdb_role_entry', $tomcat_roles, {})
 
   # split version string
   $array_version_full = split($version, '[-]')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -299,9 +299,6 @@ class tomcat (
     fail('Checksum verification requires \'checksum\' variable to be set')
   }
 
-  create_resources('::tomcat::userdb_entry', $tomcat_users, {})
-  create_resources('::tomcat::userdb_role_entry', $tomcat_roles, {})
-
   # split version string
   $array_version_full = split($version, '[-]')
   $version_real = regsubst($array_version_full[0], '[0-9]{1,2}:', '')

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,6 +40,10 @@
 #   admin user name
 # [*admin_password*]
 #   admin user password
+# [*tomcat_users*]
+#   hash containing user definitions
+# [*tomcat_roles*]
+#   hash containing role definitions
 # [*checksum_verify*]
 #   verify the checksum if tomcat is installed from an archive (boolean)
 # [*checksum_type*]
@@ -93,6 +97,8 @@ define tomcat::instance (
   $create_default_admin       = false,
   $admin_user                 = 'tomcatadmin',
   $admin_password             = 'password',
+  $tomcat_users               = {},
+  $tomcat_roles               = {},
   #..................................................................................
   # logging
   #..................................................................................
@@ -260,7 +266,7 @@ define tomcat::instance (
   validate_re($version, '^(?:[0-9]{1,2}:)?[0-9]\.[0-9]\.[0-9]{1,2}(?:-.*)?$', 'incorrect tomcat version number')
   validate_re($service_ensure, '^(stopped|running)$', '$service_ensure must be either \'stopped\', or \'running\'')
   validate_array($listeners, $executors, $connectors, $realms, $valves, $globalnaming_environments, $globalnaming_resources, $context_watchedresources, $context_parameters, $context_environments, $context_listeners, $context_valves, $context_resourcedefs, $context_resourcelinks, $catalina_opts, $java_opts, $jpda_opts)
-  validate_hash($server_params, $svc_params, $threadpool_params, $http_params, $ssl_params, $ajp_params, $engine_params, $host_params, $context_params, $context_loader, $context_manager, $context_realm, $context_resources, $custom_variables)
+  validate_hash($server_params, $svc_params, $threadpool_params, $http_params, $ssl_params, $ajp_params, $engine_params, $host_params, $context_params, $context_loader, $context_manager, $context_realm, $context_resources, $custom_variables, $tomcat_users, $tomcat_roles)
   validate_bool($checksum_verify)
   validate_re($checksum_type, '^(none|md5|sha1|sha2|sh256|sha384|sha512)$', 'The checksum type needs to be one of the following: none|md5|sha1|sha2|sh256|sha384|sha512')
 
@@ -1063,6 +1069,10 @@ define tomcat::instance (
       password => $admin_password,
       roles    => ['manager-gui', 'manager-script', 'admin-gui', 'admin-script']
     }
+
+  # Configure users and roles defined in $tomcat_users and $tomcat_roles
+  create_resources('::tomcat::userdb_entry', $tomcat_users, {database => "instance ${name} UserDatabase header"})
+  create_resources('::tomcat::userdb_role_entry', $tomcat_roles, {database => "instance ${name} UserDatabase header"})
   }
 
   # --------------#

--- a/manifests/userdb_role_entry.pp
+++ b/manifests/userdb_role_entry.pp
@@ -1,9 +1,7 @@
-# == Define: tomcat::userdb_entry
+# == Define: tomcat::userdb_role_entry
 #
-define tomcat::userdb_entry (
-  $password,
-  $roles,
-  $username = $name,
+define tomcat::userdb_role_entry (
+  $rolename = $name,
   $database = 'main UserDatabase') {
   # The base class must be included first
   if !defined(Class['tomcat']) {
@@ -11,15 +9,12 @@ define tomcat::userdb_entry (
   }
 
   # parameters validation
-  validate_array($roles)
-  validate_string($username, $password)
-
-  $roles_string = join($roles, ',')
+  validate_string($rolename)
 
   # add formated fragment
   concat::fragment { "UserDatabase entry (${title})":
     target  => $database,
-    content => template("${module_name}/common/UserDatabase_entry.erb"),
-    order   => 3
+    content => template("${module_name}/common/UserDatabase_role_entry.erb"),
+    order   => 2
   }
 }

--- a/templates/common/UserDatabase_role_entry.erb
+++ b/templates/common/UserDatabase_role_entry.erb
@@ -1,0 +1,1 @@
+  <role rolename="<%= @rolename %>"/>


### PR DESCRIPTION
- Users and roles can be defined in hiera.
- Added support for adding role definitions into tomcat-users.xml.
- Giving a username is now optional in userdb_entry. If username is not given, the hash key / define title is used as the username. This removes some repetition and makes the configuration a bit simpler - still retains backward compatibility.

Example hiera config:

```
tomcat::tomcat_roles:
    printservice:
        rolename: "printservice"
    accounting: {}

tomcat::tomcat_users:
    deployer:
        password: "secret"
        roles: ["printservice"]
    admin:
        password: "secret"
        roles: ["admingui,managergui"]
```

I now noticed that there is already a similar PR for adding roles. Sorry for the overlap.
https://github.com/antoineco/aco-tomcat/pull/49 
