### PR TITLE
Add option "file_mode" for managing file modes..

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ Tomcat user. Defaults to `${service_name}` (Debian) / `tomcat` (all other distri
 #####`tomcat_group`
 Tomcat group. Defaults to `${tomcat_user}`.
 
+#####`file_mode`
+File mode for certain configuration xml files. Defaults to '0600'.
+
 #####`extras_enable`
 Whether to install Tomcat extra libraries. Boolean value. Defaults to `false`.  
 *Warning:* extra libraries are enabled globally if defined within the global context

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -89,13 +89,14 @@ class tomcat::config {
   $jpda_suspend = $::tomcat::jpda_suspend
   $jpda_opts_real = $::tomcat::jpda_opts_real
   $custom_variables = $::tomcat::custom_variables
+  $file_mode = $::tomcat::file_mode
 
   # generate and manage server configuration
   concat { 'tomcat server configuration':
     path   => "${::tomcat::catalina_base_real}/conf/server.xml",
     owner  => $tomcat_user,
     group  => $tomcat_group,
-    mode   => '0600',
+    mode   => $file_mode,
     order  => 'numeric',
     notify => Service[$::tomcat::service_name_real]
   }
@@ -355,7 +356,7 @@ class tomcat::config {
     path   => "${::tomcat::catalina_base_real}/conf/tomcat-users.xml",
     owner  => $tomcat_user,
     group  => $tomcat_group,
-    mode   => '0600',
+    mode   => $file_mode,
     order  => 'numeric',
     notify => Service[$::tomcat::service_name_real]
   }

--- a/manifests/context.pp
+++ b/manifests/context.pp
@@ -4,6 +4,7 @@ define tomcat::context (
   $path,
   $owner            = $::tomcat::tomcat_user_real,
   $group            = $::tomcat::tomcat_group_real,
+  $file_mode        = $::tomcat::file_mode,
   $params           = {},
   $loader           = {},
   $manager          = {},
@@ -32,7 +33,7 @@ define tomcat::context (
     path  => $path,
     owner => $owner,
     group => $group,
-    mode  => '0600',
+    mode  => $file_mode,
     order => 'numeric'
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,8 @@
 #   service user
 # [*tomcat_group*]
 #   service group
+# [*file_mode*]
+#   mode for configuration files
 # [*tomcat_native*]
 #   install tomcat native library (boolean)
 # [*tomcat_native_package_name*]
@@ -107,6 +109,7 @@ class tomcat (
   $service_stop               = undef,
   $tomcat_user                = undef,
   $tomcat_group               = undef,
+  $file_mode                  = '0600',
   $tomcat_native              = false,
   $tomcat_native_package_name = $::tomcat::params::tomcat_native_package_name,
   $log4j                      = false,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -26,6 +26,8 @@
 #   service user
 # [*tomcat_group*]
 #   service group
+# [*file_mode*]
+#   mode for configuration files
 # [*extras_enable*]
 #   install extra libraries (boolean)
 # [*extras_source*]
@@ -80,6 +82,7 @@ define tomcat::instance (
   $service_stop               = undef,
   $tomcat_user                = $::tomcat::tomcat_user_real,
   $tomcat_group               = $::tomcat::tomcat_group_real,
+  $file_mode                  = '0600',
   $extras_enable              = false,
   $enable_extras              = undef, #! backward compatibility
   $extras_source              = undef,
@@ -818,7 +821,7 @@ define tomcat::instance (
     path    => "${catalina_base_real}/conf/server.xml",
     owner   => $tomcat_user,
     group   => $tomcat_group,
-    mode    => '0600',
+    mode    => $file_mode,
     order   => 'numeric',
     notify  => Service[$service_name_real],
     require => File["${catalina_base_real}/conf"]
@@ -1043,7 +1046,7 @@ define tomcat::instance (
         ensure  => present,
         owner   => $tomcat_user,
         group   => $tomcat_group,
-        mode    => '0600',
+        mode    => $file_mode,
         path    => "${catalina_base_real}/conf/web.xml",
         source  => "puppet:///modules/${module_name}/conf/web.xml",
         require => File["${catalina_base_real}/conf"]
@@ -1093,7 +1096,7 @@ define tomcat::instance (
     path   => "${catalina_base_real}/conf/tomcat-users.xml",
     owner  => $tomcat_user,
     group  => $tomcat_group,
-    mode   => '0600',
+    mode   => $file_mode,
     order  => 'numeric',
     notify => Service[$service_name_real]
   }


### PR DESCRIPTION
..of certain xml files:

server.xml
web.xml
tomcat-users.xml
context.xml

By default the file mode is 0600

This change is needed because I had set ACL rules for these files and this module overrides those rules.