### PR TITLE
Fixed Could not find resource 'Tomcat::Context[instance...admin_context]'

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1279,9 +1279,8 @@ define tomcat::instance (
 
       # ordering
       File <| tag == "instance_${name}_catalina_tree" |>
-      -> Tomcat::Context["instance ${name} manager.xml"]
-      -> Tomcat::Context["instance ${name} host-manager.xml"]
-
+      -> Tomcat::Context <| tag == "instance_${name}_admin_context" |>
+      
     } else {
       # warn if admin webapps were selected for installation in a multi-version setup
       if $admin_webapps {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1280,7 +1280,7 @@ define tomcat::instance (
       # ordering
       File <| tag == "instance_${name}_catalina_tree" |>
       -> Tomcat::Context <| tag == "instance_${name}_admin_context" |>
-      
+
     } else {
       # warn if admin webapps were selected for installation in a multi-version setup
       if $admin_webapps {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1278,7 +1278,10 @@ define tomcat::instance (
       }
 
       # ordering
-      Tomcat::Context["instance_${name}_admin_context"] -> File <| tag == "instance_${name}_catalina_tree" |>
+      File <| tag == "instance_${name}_catalina_tree" |>
+      -> Tomcat::Context["instance ${name} manager.xml"]
+      -> Tomcat::Context["instance ${name} host-manager.xml"]
+
     } else {
       # warn if admin webapps were selected for installation in a multi-version setup
       if $admin_webapps {


### PR DESCRIPTION

Fixed errors like Could not find resource 'Tomcat::Context[instance_xxx_admin_context]' for relationship on 'File[/opt/tomcat/instances/xx/conf/Catalina]' when instances are created. 

Two problems were here:
- Resource reference doesn't work with tags (so added the two tomcat::context reference) (resources collections need them, so File <| tag = .. |> is kept)
- Ordering was reversed: first we need the directory then the files inside.