### PR TITLE
fixed missing @, when using user-data-contstraint

### DIFF
--- a/templates/common/web.xml/070_security_constraint.erb
+++ b/templates/common/web.xml/070_security_constraint.erb
@@ -33,7 +33,7 @@
         <%- if ! @udc.empty? -%>
         <user-data-constraint>
             <%- if @udc.has_key?('transport-guarantee') -%>
-            <transport-guarantee><%= udc['transport-guarantee'].encode(:xml => :text) %></transport-guarantee>
+            <transport-guarantee><%= @udc['transport-guarantee'].encode(:xml => :text) %></transport-guarantee>
             <%- end -%>
         </user-data-constraint>
         <%- end -%>


### PR DESCRIPTION
This fixes the following error:
```
Error: Failed to parse template tomcat/common/web.xml/070_security_constraint.erb:
  Filepath: /usr/share/ruby/vendor_ruby/puppet/parser/templatewrapper.rb
  Line: 82
  Detail: Could not find value for 'udc' at /etc/puppet/environments/production/modules/tomcat/templates/common/web.xml/070_security_constraint.erb:36
 at /etc/puppet/environments/production/modules/tomcat/manifests/web.pp:133 on node jenkins.localhost
Error: Failed to parse template tomcat/common/web.xml/070_security_constraint.erb:
  Filepath: /usr/share/ruby/vendor_ruby/puppet/parser/templatewrapper.rb
  Line: 82
  Detail: Could not find value for 'udc' at /etc/puppet/environments/production/modules/tomcat/templates/common/web.xml/070_security_constraint.erb:36
 at /etc/puppet/environments/production/modules/tomcat/manifests/web.pp:133 on node jenkins.localhost
```
this is what I'm using in hiera:

````
---

    tomcat::security_constraints:
      - display-name: 'Security constraint 1'
        user-data-constraint:
          transport-guarantee: 'CONFIDENTIAL'
        web-resource-collection:
          url-pattern:
            - '/*'
```
