### PR TITLE
Add systemd management for Debian 8 and 9 + add run levels in init.d script

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -175,6 +175,7 @@ class tomcat::params {
             '9'     : {
               $version = '8.5.14-1+deb9u2'
               $package_name = 'tomcat8'
+              $systemd = true
             }
             # jessie
             # https://packages.debian.org/jessie/tomcat8
@@ -183,6 +184,7 @@ class tomcat::params {
               $package_name = 'tomcat8'
               # $version = '7.0.56-3+deb8u10'
               # $package_name = 'tomcat7'
+              $systemd = true
             }
             # wheezy
             # https://packages.debian.org/wheezy/tomcat7

--- a/templates/instance/tomcat_init_generic.erb
+++ b/templates/instance/tomcat_init_generic.erb
@@ -12,8 +12,8 @@
 # Provides: tomcat
 # Required-Start: $network $syslog
 # Required-Stop: $network $syslog
-# Default-Start:
-# Default-Stop:
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
 # Description: Release implementation for Servlet 2.5 and JSP 2.1
 # Short-Description: start and stop tomcat
 ### END INIT INFO


### PR DESCRIPTION
Hello,

I modified params.pp to add systemd = true for Debian 8 and 9 (systemd was introduced in Debian 8) and I did add the run levels for default-start and default-stop in the init.d script template (the values are from the init.d script provided by the official Debian package).