### PR TITLE
Parameterize the default mirror address

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,10 +418,10 @@ Must include the full package suffix on Debian variants.
 Base path of the source of the Tomcat installation archive, if installed from archive. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `${archive_mirror}/dist/tomcat/tomcat-<maj_version>/v<version>/bin`.
 
 ##### `archive_filename`
-File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`
+File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`.
 
 ##### `archive_mirror`
-Mirror to use if installed from archive and no archive source was provided but version was. Defaults to `http://archive.apache.org`
+Mirror to use if installed from archive and no archive source was provided but version was. Defaults to `http://archive.apache.org`.
 
 ##### `proxy_server`
 URL of a proxy server used for downloading Tomcat archives

--- a/README.md
+++ b/README.md
@@ -415,10 +415,13 @@ Must include the full package suffix on Debian variants.
 *Note:* multi-version only supported if installed from archive
 
 ##### `archive_source`
-Base path of the source of the Tomcat installation archive, if installed from archive. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `http://archive.apache.org/dist/tomcat/tomcat-<maj_version>/v<version>/bin`.
+Base path of the source of the Tomcat installation archive, if installed from archive. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `${archive_mirror}/dist/tomcat/tomcat-<maj_version>/v<version>/bin`.
 
 ##### `archive_filename`
-File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`.
+File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`
+
+##### `archive_mirror`
+Mirror to use if installed from archive and no archive source was provided but version was. Defaults to `http://archive.apache.org`
 
 ##### `proxy_server`
 URL of a proxy server used for downloading Tomcat archives
@@ -473,7 +476,7 @@ Whether to install Tomcat extra libraries. Boolean value. Defaults to `false`.
 *Warning:* extra libraries are enabled globally if defined within the global context
 
 ##### `extras_source`
-Base path of the source of the Tomcat extra libraries. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `http://archive.apache.org/dist/tomcat/tomcat-<maj_version>/v<version>/bin/extras`.
+Base path of the source of the Tomcat extra libraries. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `${archive_mirror}/dist/tomcat/tomcat-<maj_version>/v<version>/bin/extras`.
 
 ##### `manage_firewall`
 Whether to automatically manage firewall rules. Boolean value. Defaults to `false`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@
 #   base path to the archive to download (only if installed from archive)
 # [*archive_filename*]
 #   file name of the archive to download (only if installed from archive)
+# [*archive_mirror*]
+#   mirror to use if installed from archive and no archive source was provided but version was
 # [*proxy_server*]
 #   proxy server url
 # [*proxy_type*]
@@ -104,6 +106,7 @@ class tomcat (
   $version                    = $::tomcat::params::version,
   $archive_source             = undef,
   $archive_filename           = undef,
+  $archive_mirror             = 'http://archive.apache.org',
   $proxy_server               = undef,
   $proxy_type                 = undef,
   $package_name               = $::tomcat::params::package_name,
@@ -381,7 +384,7 @@ class tomcat (
   }
 
   if $archive_source == undef {
-    $archive_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
+    $archive_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
   } else {
     $archive_source_real = $archive_source
   }
@@ -393,7 +396,7 @@ class tomcat (
   }
 
   if $extras_source == undef {
-    $extras_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
+    $extras_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
   } else {
     $extras_source_real = $extras_source
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -12,6 +12,8 @@
 #   base path to the archive to download (only if installed from archive)
 # [*archive_filename*]
 #   file name of the archive to download (only if installed from archive)
+# [*archive_mirror*]
+#   mirror to use if installed from archive and no archive source was provided but version was
 # [*proxy_server*]
 #   proxy server url
 # [*proxy_type*]
@@ -81,6 +83,7 @@ define tomcat::instance (
   $version                    = $::tomcat::version_real,
   $archive_source             = undef,
   $archive_filename           = undef,
+  $archive_mirror             = 'http://archive.apache.org',
   $proxy_server               = undef,
   $proxy_type                 = undef,
   $service_name               = undef,
@@ -362,7 +365,7 @@ define tomcat::instance (
   }
 
   if $archive_source == undef {
-    $archive_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
+    $archive_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
   } else {
     $archive_source_real = $archive_source
   }
@@ -374,7 +377,7 @@ define tomcat::instance (
   }
 
   if $extras_source == undef {
-    $extras_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
+    $extras_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
   } else {
     $extras_source_real = $extras_source
   }


### PR DESCRIPTION
We would appreciate to be able to give the module a mirror address and a version without having to give the full archive name every time.

Hope this is good enough,
Thanks ! =)