### PR TITLE
Make exec for systemctl search in /usr/bin and /bin

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -842,7 +842,8 @@ define tomcat::instance (
     }
     # Refresh systemd configuration
     exec { "refresh ${service_name_real}":
-      command     => '/usr/bin/systemctl daemon-reload',
+      path        => ['usr/bin/','/bin/'],
+      command     => 'systemctl daemon-reload',
       refreshonly => true,
       subscribe   => File["${service_name_real} service unit"],
       notify      => $notify_service

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -842,7 +842,7 @@ define tomcat::instance (
     }
     # Refresh systemd configuration
     exec { "refresh ${service_name_real}":
-      path        => ['usr/bin/','/bin/'],
+      path        => ['/usr/bin/','/bin/'],
       command     => 'systemctl daemon-reload',
       refreshonly => true,
       subscribe   => File["${service_name_real} service unit"],

--- a/manifests/service/archive.pp
+++ b/manifests/service/archive.pp
@@ -41,7 +41,8 @@ class tomcat::service::archive {
     }
     # Refresh systemd configuration
     exec { "refresh ${service_name_real}":
-      command     => '/usr/bin/systemctl daemon-reload',
+      path        => ['usr/bin/','/bin/'],
+      command     => 'systemctl daemon-reload',
       refreshonly => true,
       subscribe   => File["${service_name_real} service unit"],
       notify      => $notify_service

--- a/manifests/service/archive.pp
+++ b/manifests/service/archive.pp
@@ -41,7 +41,7 @@ class tomcat::service::archive {
     }
     # Refresh systemd configuration
     exec { "refresh ${service_name_real}":
-      path        => ['usr/bin/','/bin/'],
+      path        => ['/usr/bin/','/bin/'],
       command     => 'systemctl daemon-reload',
       refreshonly => true,
       subscribe   => File["${service_name_real} service unit"],


### PR DESCRIPTION
Hi Antoine,
for Debian Stretch the path is /bin instead of /usr/bin. This PR makes the necessary changes for the exec to look in both locations.
