### PR TITLE
Add parameter to disable puppet service management

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,10 +418,10 @@ Must include the full package suffix on Debian variants.
 Base path of the source of the Tomcat installation archive, if installed from archive. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `${archive_mirror}/dist/tomcat/tomcat-<maj_version>/v<version>/bin`.
 
 ##### `archive_filename`
-File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`
+File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`.
 
 ##### `archive_mirror`
-Mirror to use if installed from archive and no archive source was provided but version was. Defaults to `http://archive.apache.org`
+Mirror to use if installed from archive and no archive source was provided but version was. Defaults to `http://archive.apache.org`.
 
 ##### `proxy_server`
 URL of a proxy server used for downloading Tomcat archives

--- a/README.md
+++ b/README.md
@@ -415,10 +415,13 @@ Must include the full package suffix on Debian variants.
 *Note:* multi-version only supported if installed from archive
 
 ##### `archive_source`
-Base path of the source of the Tomcat installation archive, if installed from archive. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `http://archive.apache.org/dist/tomcat/tomcat-<maj_version>/v<version>/bin`.
+Base path of the source of the Tomcat installation archive, if installed from archive. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `${archive_mirror}/dist/tomcat/tomcat-<maj_version>/v<version>/bin`.
 
 ##### `archive_filename`
-File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`.
+File name of the Tomcat installation archive, if installed from archive. Defaults to `apache-tomcat-<version>.tar.gz`
+
+##### `archive_mirror`
+Mirror to use if installed from archive and no archive source was provided but version was. Defaults to `http://archive.apache.org`
 
 ##### `proxy_server`
 URL of a proxy server used for downloading Tomcat archives
@@ -473,7 +476,7 @@ Whether to install Tomcat extra libraries. Boolean value. Defaults to `false`.
 *Warning:* extra libraries are enabled globally if defined within the global context
 
 ##### `extras_source`
-Base path of the source of the Tomcat extra libraries. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `http://archive.apache.org/dist/tomcat/tomcat-<maj_version>/v<version>/bin/extras`.
+Base path of the source of the Tomcat extra libraries. Supports local files, puppet://, http://, https:// and ftp://. Defaults to `${archive_mirror}/dist/tomcat/tomcat-<maj_version>/v<version>/bin/extras`.
 
 ##### `manage_firewall`
 Whether to automatically manage firewall rules. Boolean value. Defaults to `false`.

--- a/README.md
+++ b/README.md
@@ -441,6 +441,9 @@ Checksum to test against. Defaults to `undef`.
 ##### `service_name`
 Tomcat service name. Defaults to [`${package_name}`](#package_name) (global) / `${package_name}_${title}` (instance).
 
+##### `service_manage`
+Wether the service should be managed. Boolean value. Defaults to `true`.
+
 ##### `service_ensure`
 Whether the service should be running. Valid values are `stopped` and `running`. Defaults to `running`.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,8 @@
 #   tomcat package 'ensure' attribute (falls back to value of '$version')
 # [*service_name*]
 #   tomcat service name
+# [*service_manage*]
+#   wether the service should be managed through puppet (boolean, defaults to true)
 # [*service_ensure*]
 #   whether the service should be running (valid: 'stopped'|'running'|undef)
 # [*service_enable*]
@@ -112,6 +114,7 @@ class tomcat (
   $package_name               = $::tomcat::params::package_name,
   $package_ensure             = undef,
   $service_name               = undef,
+  $service_manage             = true,
   $service_ensure             = 'running',
   $service_enable             = true,
   $restart_on_change          = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@
 #   base path to the archive to download (only if installed from archive)
 # [*archive_filename*]
 #   file name of the archive to download (only if installed from archive)
+# [*archive_mirror*]
+#   mirror to use if installed from archive and no archive source was provided but version was
 # [*proxy_server*]
 #   proxy server url
 # [*proxy_type*]
@@ -104,6 +106,7 @@ class tomcat (
   $version                    = $::tomcat::params::version,
   $archive_source             = undef,
   $archive_filename           = undef,
+  $archive_mirror             = 'http://archive.apache.org',
   $proxy_server               = undef,
   $proxy_type                 = undef,
   $package_name               = $::tomcat::params::package_name,
@@ -381,7 +384,7 @@ class tomcat (
   }
 
   if $archive_source == undef {
-    $archive_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
+    $archive_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
   } else {
     $archive_source_real = $archive_source
   }
@@ -393,7 +396,7 @@ class tomcat (
   }
 
   if $extras_source == undef {
-    $extras_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
+    $extras_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
   } else {
     $extras_source_real = $extras_source
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -12,6 +12,8 @@
 #   base path to the archive to download (only if installed from archive)
 # [*archive_filename*]
 #   file name of the archive to download (only if installed from archive)
+# [*archive_mirror*]
+#   mirror to use if installed from archive and no archive source was provided but version was
 # [*proxy_server*]
 #   proxy server url
 # [*proxy_type*]
@@ -81,6 +83,7 @@ define tomcat::instance (
   $version                    = $::tomcat::version_real,
   $archive_source             = undef,
   $archive_filename           = undef,
+  $archive_mirror             = 'http://archive.apache.org',
   $proxy_server               = undef,
   $proxy_type                 = undef,
   $service_name               = undef,
@@ -362,7 +365,7 @@ define tomcat::instance (
   }
 
   if $archive_source == undef {
-    $archive_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
+    $archive_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin"
   } else {
     $archive_source_real = $archive_source
   }
@@ -374,7 +377,7 @@ define tomcat::instance (
   }
 
   if $extras_source == undef {
-    $extras_source_real = "http://archive.apache.org/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
+    $extras_source_real = "${archive_mirror}/dist/tomcat/tomcat-${maj_version}/v${version_real}/bin/extras"
   } else {
     $extras_source_real = $extras_source
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -20,6 +20,8 @@
 #   proxy server type (valid: 'none'|'http'|'https'|'ftp')
 # [*service_name*]
 #   tomcat service name
+# [*service_manage*]
+#   wether the service should be managed through puppet (boolean, defaults to true)
 # [*service_ensure*]
 #   whether the service should be running (valid: 'stopped'|'running'|undef)
 # [*service_enable*]
@@ -87,6 +89,7 @@ define tomcat::instance (
   $proxy_server               = undef,
   $proxy_type                 = undef,
   $service_name               = undef,
+  $service_manage             = true,
   $service_ensure             = 'running',
   $service_enable             = true,
   $restart_on_change          = $::tomcat::restart_on_change,
@@ -898,10 +901,12 @@ define tomcat::instance (
   $cluster_farm_deployer_watchdir_real = pick($cluster_farm_deployer_watchdir,"${catalina_base_real}/deploy")
   $cluster_farm_deployer_deploydir_real = pick($cluster_farm_deployer_deploydir, "${catalina_base_real}/webapps")
 
-  service { $service_name_real:
-    ensure  => $service_ensure,
-    enable  => $service_enable,
-    require => File["${service_name_real} service unit"];
+  if $::tomcat::service_manage {
+    service { $service_name_real:
+      ensure  => $service_ensure,
+      enable  => $service_enable,
+      require => File["${service_name_real} service unit"];
+    }
   }
 
   # --------------------#

--- a/manifests/service/archive.pp
+++ b/manifests/service/archive.pp
@@ -68,9 +68,11 @@ class tomcat::service::archive {
     }
   }
 
-  service { $service_name_real:
-    ensure  => $::tomcat::service_ensure,
-    enable  => $::tomcat::service_enable,
-    require => File["${service_name_real} service unit"];
+  if $::tomcat::service_manage {
+    service { $service_name_real:
+      ensure  => $::tomcat::service_ensure,
+      enable  => $::tomcat::service_enable,
+      require => File["${service_name_real} service unit"];
+    }
   }
 }

--- a/manifests/service/package.pp
+++ b/manifests/service/package.pp
@@ -9,8 +9,10 @@ class tomcat::service::package {
   }
 
   # tomcat service
-  service { $::tomcat::service_name_real:
-    ensure => $::tomcat::service_ensure,
-    enable => $::tomcat::service_enable
+  if $::tomcat::service_manage {
+    service { $::tomcat::service_name_real:
+      ensure => $::tomcat::service_ensure,
+      enable => $::tomcat::service_enable
+    }
   }
 }


### PR DESCRIPTION
Hello!

We would like to have the option to manage the service entirely ourselves, not though puppet, and I thought I could add a parameter for that purpose.
Thank you for the review!